### PR TITLE
feat(no-http-url): add support for template literals

### DIFF
--- a/src/rules/no-http-url.test.ts
+++ b/src/rules/no-http-url.test.ts
@@ -6,17 +6,39 @@ const valid = [
 	`'http'`,
 	`'//github.com'`,
 	`'https://github.com'`,
+	'`https://github.com`',
+	`"https://github.com"`,
 	`'&url=https://github.com'`,
 	`'http://localhost'`,
 	`'http://localhost:8080'`,
 	`'http://127.0.0.1'`,
 	`'http://127.0.0.1:30'`,
+	'`http://localhost`',
+	`"http://localhost"`,
+	'`\nhttp://localhost\n`',
+	'`my profile url is https://example.com/ryoppippi`',
 ];
 
 const invalids = [
 	[
 		`'http://github.com'`,
 		`'https://github.com'`,
+	],
+	[
+		'`http://github.com`',
+		'`https://github.com`',
+	],
+	[
+		`"http://github.com"`,
+		`"https://github.com"`,
+	],
+	[
+		'`\nhttp://github.com/ryoppippi\n`',
+		'`\nhttps://github.com/ryoppippi\n`',
+	],
+	[
+		'`my profile url is http://example.com/ryoppippi`',
+		'`my profile url is https://example.com/ryoppippi`',
 	],
 	[
 		`'&url=http://github.com'`,


### PR DESCRIPTION
This update extends the no-http-url rule to detect and fix HTTP URLs inside template literals, in addition to regular string literals. The rule now detects HTTP URLs in backtick templates and can automatically replace them with HTTPS URLs.

The implementation extracts common URL checking logic into a reusable function to avoid code duplication between string and template literal handling.