### PR TITLE
fix: handle template literals with expressions properly

### DIFF
--- a/src/rules/no-http-url.test.ts
+++ b/src/rules/no-http-url.test.ts
@@ -41,6 +41,18 @@ const invalids = [
 		'`my profile url is https://example.com/ryoppippi`',
 	],
 	[
+		// eslint-disable-next-line no-template-curly-in-string
+		'`http://github.com/ryoppippi/${path}`',
+		// eslint-disable-next-line no-template-curly-in-string
+		'`https://github.com/ryoppippi/${path}`',
+	],
+	[
+		// eslint-disable-next-line no-template-curly-in-string
+		'`http://github.com/ryoppippi/${path}/${path2}`',
+		// eslint-disable-next-line no-template-curly-in-string
+		'`https://github.com/ryoppippi/${path}/${path2}`',
+	],
+	[
 		`'&url=http://github.com'`,
 		`'&url=https://github.com'`,
 	],

--- a/src/rules/no-http-url.test.ts
+++ b/src/rules/no-http-url.test.ts
@@ -25,16 +25,24 @@ const invalids = [
 		`'https://github.com'`,
 	],
 	[
-		'`http://github.com`',
-		'`https://github.com`',
-	],
-	[
 		`"http://github.com"`,
 		`"https://github.com"`,
 	],
 	[
+		`"http://github.com http://ryoppippi.com"`,
+		`"https://github.com https://ryoppippi.com"`,
+	],
+	[
+		'`http://github.com`',
+		'`https://github.com`',
+	],
+	[
 		'`\nhttp://github.com/ryoppippi\n`',
 		'`\nhttps://github.com/ryoppippi\n`',
+	],
+	[
+		'`http://example.com/ryoppippi http://example.com/ryoppippi-2 https://example.com/ryoppippi`',
+		'`https://example.com/ryoppippi https://example.com/ryoppippi-2 https://example.com/ryoppippi`',
 	],
 	[
 		'`my profile url is http://example.com/ryoppippi`',

--- a/src/rules/no-http-url.ts
+++ b/src/rules/no-http-url.ts
@@ -4,6 +4,11 @@ import { docUrl } from '../utils' with {type: 'macro'};
 export const RULE_NAME = `no-http-url`;
 export const MESSAGE_ID = `httpNotAllowed`;
 
+// Top-level regex definitions
+const URL_REGEXP = /http:\/\//i;
+// eslint-disable-next-line regexp/no-unused-capturing-group
+const LOCAL_REGEXP = /(localhost|127\.0\.0\.1)/i;
+
 const rule = ({
 	meta: {
 		type: 'problem',
@@ -22,17 +27,13 @@ const rule = ({
 		 * Check whether the URL is HTTP and fix it to HTTPS.
 		 */
 		const checkHttpUrl = (node: Rule.Node, value: string, raw: string | null | undefined): void => {
-			const urlRegexp = /http:\/\//i;
-			// eslint-disable-next-line regexp/no-unused-capturing-group
-			const localRegexp = /(localhost|127\.0\.0\.1)/i;
-
 			if (
 				value != null
 				&& typeof value === 'string'
 				// eslint-disable-next-line ts/strict-boolean-expressions
-				&& value.match(urlRegexp)
+				&& value.match(URL_REGEXP)
 				// eslint-disable-next-line ts/strict-boolean-expressions
-				&& !value.match(localRegexp)
+				&& !value.match(LOCAL_REGEXP)
 			) {
 				context.report({
 					node,
@@ -41,7 +42,7 @@ const rule = ({
 						if (raw == null) {
 							return null;
 						}
-						const result = raw.replace(urlRegexp, 'https://');
+						const result = raw.replace(URL_REGEXP, 'https://');
 						return fixer.replaceText(node, result);
 					},
 				});
@@ -57,15 +58,26 @@ const rule = ({
 				}
 			},
 			TemplateLiteral: (node) => {
-				const quasi = node.quasis[0];
-				const value = quasi.value.cooked;
-				const raw = `\`${quasi.value.raw}\``;
+				// Handle template literals correctly, keeping all quasi and expression parts
+				const sourceCode = context.sourceCode;
+				const fullText = sourceCode.getText(node);
+				const value = node.quasis.map(q => q.value.cooked).join('');
 
-				if (value == null) {
-					return;
+				if (
+					// eslint-disable-next-line ts/strict-boolean-expressions
+					value.match(URL_REGEXP)
+					// eslint-disable-next-line ts/strict-boolean-expressions
+					&& !value.match(LOCAL_REGEXP)
+				) {
+					context.report({
+						node,
+						messageId: MESSAGE_ID,
+						fix(fixer) {
+							const newText = fullText.replace(URL_REGEXP, 'https://');
+							return fixer.replaceText(node, newText);
+						},
+					});
 				}
-
-				checkHttpUrl(node, value, raw);
 			},
 		};
 	},

--- a/src/rules/no-http-url.ts
+++ b/src/rules/no-http-url.ts
@@ -5,9 +5,8 @@ export const RULE_NAME = `no-http-url`;
 export const MESSAGE_ID = `httpNotAllowed`;
 
 // Top-level regex definitions
-const URL_REGEXP = /http:\/\//i;
-// eslint-disable-next-line regexp/no-unused-capturing-group
-const LOCAL_REGEXP = /(localhost|127\.0\.0\.1)/i;
+const URL_REGEXP = /http:\/\//gi;
+const LOCAL_REGEXP = /localhost|127\.0\.0\.1/gi;
 
 const rule = ({
 	meta: {


### PR DESCRIPTION
Previously, the no-http-url rule only considered the first part of template literals and ignored expressions. This change improves the handling of template literals with embedded expressions by:

1. Moving regex definitions to the top level for reuse
2. Examining all parts of template literals to catch HTTP URLs
3. Properly replacing HTTP with HTTPS while preserving expressions
4. Adding tests with template literal expressions for validation