### PR TITLE
Configure allowed origin for no-http-url rule

### DIFF
--- a/src/rules/no-http-url.md
+++ b/src/rules/no-http-url.md
@@ -17,3 +17,17 @@ This rule aims to ensure that all URLs are HTTPS.
 ```ts
 'http://example.com'; // 👎 error
 ```
+
+## Options
+
+This rule accepts an optional configuration object with an `allowedOrigins` array. The default value for `allowedOrigins` is `['localhost', '127.0.0.1']`.
+
+### Example
+
+```ts
+/* eslint no-http-url: ["error", { "allowedOrigins": ["custom.com"] }] */
+
+'http://custom.com'; // 👍 ok
+
+'http://example.com'; // 👎 error
+```

--- a/src/rules/no-http-url.md
+++ b/src/rules/no-http-url.md
@@ -25,7 +25,7 @@ This rule accepts an optional configuration object with an `allowedOrigins` arra
 ### Example
 
 ```ts
-/* eslint no-http-url: ["error", { "allowedOrigins": ["custom.com"] }] */
+// eslint no-http-url: ["error", { "allowedOrigins": ["custom.com"] }]
 
 'http://custom.com'; // 👍 ok
 

--- a/src/rules/no-http-url.test.ts
+++ b/src/rules/no-http-url.test.ts
@@ -17,6 +17,11 @@ const valid = [
 	`"http://localhost"`,
 	'`\nhttp://localhost\n`',
 	'`my profile url is https://example.com/ryoppippi`',
+	// Test with custom allowedOrigins
+	{
+		code: `'http://custom.com'`,
+		options: [{ allowedOrigins: ['custom.com'] }],
+	},
 ];
 
 const invalids = [
@@ -64,6 +69,12 @@ const invalids = [
 		`'&url=http://github.com'`,
 		`'&url=https://github.com'`,
 	],
+	// Test with custom allowedOrigins
+	[
+		`'http://notallowed.com'`,
+		`'https://notallowed.com'`,
+		[{ allowedOrigins: ['custom.com'] }],
+	],
 ];
 
 await run({
@@ -73,6 +84,7 @@ await run({
 	invalid: invalids.map(i => ({
 		code: i[0],
 		output: i[1],
+		options: i[2],
 		errors: [{ messageId: 'httpNotAllowed' }],
 	})),
 });

--- a/src/rules/no-http-url.test.ts
+++ b/src/rules/no-http-url.test.ts
@@ -24,67 +24,73 @@ const valid = [
 	},
 ];
 
-const invalids = [
-	[
-		`'http://github.com'`,
-		`'https://github.com'`,
-	],
-	[
-		`"http://github.com"`,
-		`"https://github.com"`,
-	],
-	[
-		`"http://github.com http://ryoppippi.com"`,
-		`"https://github.com https://ryoppippi.com"`,
-	],
-	[
-		'`http://github.com`',
-		'`https://github.com`',
-	],
-	[
-		'`\nhttp://github.com/ryoppippi\n`',
-		'`\nhttps://github.com/ryoppippi\n`',
-	],
-	[
-		'`http://example.com/ryoppippi http://example.com/ryoppippi-2 https://example.com/ryoppippi`',
-		'`https://example.com/ryoppippi https://example.com/ryoppippi-2 https://example.com/ryoppippi`',
-	],
-	[
-		'`my profile url is http://example.com/ryoppippi`',
-		'`my profile url is https://example.com/ryoppippi`',
-	],
-	[
+const invalid = [
+	{
+		code: `'http://github.com'`,
+		output: `'https://github.com'`,
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: `"http://github.com"`,
+		output: `"https://github.com"`,
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: `"http://github.com http://ryoppippi.com"`,
+		output: `"https://github.com https://ryoppippi.com"`,
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: '`http://github.com`',
+		output: '`https://github.com`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: '`\nhttp://github.com/ryoppippi\n`',
+		output: '`\nhttps://github.com/ryoppippi\n`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: '`http://example.com/ryoppippi http://example.com/ryoppippi-2 https://example.com/ryoppippi`',
+		output: '`https://example.com/ryoppippi https://example.com/ryoppippi-2 https://example.com/ryoppippi`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: '`my profile url is http://example.com/ryoppippi`',
+		output: '`my profile url is https://example.com/ryoppippi`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
 		// eslint-disable-next-line no-template-curly-in-string
-		'`http://github.com/ryoppippi/${path}`',
+		code: '`http://github.com/ryoppippi/${path}`',
 		// eslint-disable-next-line no-template-curly-in-string
-		'`https://github.com/ryoppippi/${path}`',
-	],
-	[
+		output: '`https://github.com/ryoppippi/${path}`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
 		// eslint-disable-next-line no-template-curly-in-string
-		'`http://github.com/ryoppippi/${path}/${path2}`',
+		code: '`http://github.com/ryoppippi/${path}/${path2}`',
 		// eslint-disable-next-line no-template-curly-in-string
-		'`https://github.com/ryoppippi/${path}/${path2}`',
-	],
-	[
-		`'&url=http://github.com'`,
-		`'&url=https://github.com'`,
-	],
+		output: '`https://github.com/ryoppippi/${path}/${path2}`',
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
+	{
+		code: `'&url=http://github.com'`,
+		output: `'&url=https://github.com'`,
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
 	// Test with custom allowedOrigins
-	[
-		`'http://notallowed.com'`,
-		`'https://notallowed.com'`,
-		[{ allowedOrigins: ['custom.com'] }],
-	],
+	{
+		code: `'http://notallowed.com'`,
+		output: `'https://notallowed.com'`,
+		options: [{ allowedOrigins: ['custom.com'] }],
+		errors: [{ messageId: 'httpNotAllowed' }],
+	},
 ];
 
 await run({
 	name: RULE_NAME,
 	rule,
 	valid,
-	invalid: invalids.map(i => ({
-		code: i[0],
-		output: i[1],
-		options: i[2],
-		errors: [{ messageId: 'httpNotAllowed' }],
-	})),
+	invalid,
 });

--- a/src/rules/no-http-url.ts
+++ b/src/rules/no-http-url.ts
@@ -40,8 +40,8 @@ const rule = ({
 		},
 	},
 	create: (context) => {
-		const options = context.options[0] || {};
-		const allowedOrigins = options.allowedOrigins || DEFAULT_ALLOWED_ORIGIN;
+		const options = (context.options.at(0) ?? {}) as { allowedOrigins?: readonly string[] };
+		const allowedOrigins = options?.allowedOrigins ?? DEFAULT_ALLOWED_ORIGIN;
 		const LOCAL_REGEXP = new RegExp(allowedOrigins.join('|'), 'gi');
 
 		/**

--- a/src/rules/no-http-url.ts
+++ b/src/rules/no-http-url.ts
@@ -4,9 +4,13 @@ import { docUrl } from '../utils' with {type: 'macro'};
 export const RULE_NAME = `no-http-url`;
 export const MESSAGE_ID = `httpNotAllowed`;
 
+/**
+ * Default allowed origins for HTTP URLs.
+ */
+const DEFAULT_ALLOWED_ORIGIN = ['localhost', '127.0.0.1'] as const;
+
 // Top-level regex definitions
 const URL_REGEXP = /http:\/\//gi;
-const LOCAL_REGEXP = /localhost|127\.0\.0\.1/gi;
 
 const rule = ({
 	meta: {
@@ -15,13 +19,31 @@ const rule = ({
 			description: 'disallow http url',
 			url: docUrl('no-http-url'),
 		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					allowedOrigins: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
+						default: DEFAULT_ALLOWED_ORIGIN,
+					},
+				},
+				additionalProperties: false,
+			},
+		],
 		fixable: 'code',
-		schema: [],
 		messages: {
 			[MESSAGE_ID]: 'HTTP is not safe enough. use HTTPS.',
 		},
 	},
 	create: (context) => {
+		const options = context.options[0] || {};
+		const allowedOrigins = options.allowedOrigins || DEFAULT_ALLOWED_ORIGIN;
+		const LOCAL_REGEXP = new RegExp(allowedOrigins.join('|'), 'gi');
+
 		/**
 		 * Check whether the URL is HTTP and fix it to HTTPS.
 		 */


### PR DESCRIPTION
Fixes #18

Add configuration option for allowed origins in `no-http-url` rule.

* **src/rules/no-http-url.ts**
  - Add an optional configuration object with an `allowedOrigins` array.
  - Set the default value for `allowedOrigins` to `DEFAULT_ALLOWED_ORIGIN`.
  - Define a constant `DEFAULT_ALLOWED_ORIGIN` with value `['localhost', '127.0.0.1']`.
  - Update the logic to check against the `allowedOrigins` array.
  - Add JSDoc to `DEFAULT_ALLOWED_ORIGIN`.

* **src/rules/no-http-url.test.ts**
  - Add tests for the rule with the default `allowedOrigins`.
  - Add tests for the rule with custom `allowedOrigins`.

* **src/rules/no-http-url.md**
  - Add documentation for the new `allowedOrigins` configuration option.
  - Provide examples for using the `allowedOrigins` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ryoppippi/eslint-plugin-ryoppippi/pull/19?shareId=08e90825-e87b-4675-af9c-c117d35ce176).