### PR TITLE
fix: incorrect github url

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": "",
 	"license": "MIT",
 	"funding": "https://github.com/ryoppippi",
-	"repository": "https://github.com/eslint-plugin-ryoppippi",
+	"repository": "https://github.com/ryoppippi/eslint-plugin-ryoppippi",
 	"keywords": [
 		"eslint",
 		"eslint-plugin",


### PR DESCRIPTION
## Describe your changes
Current URL: `https://github.com/eslint-plugin-ryoppippi`
Correct URL: `https://github.com/ryoppippi/eslint-plugin-ryoppippi`

## Issue ticket number and link

fix #21

## Checklist before requesting a review

- [x] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
