### PR TITLE
test: run packages as a Vitest workspace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           github_access_token: ${{ github.token }}
       - run: nix develop --command vp install --frozen-lockfile
       - run: nix develop --command vp run check
-      - run: nix develop --command vp run -r test
+      - run: nix develop --command vp run test
       - run: nix fmt -- --fail-on-change
       - run: nix flake check
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"check": "vp run -r build && vp check",
 		"format": "vp fmt",
 		"lint": "vp lint",
-		"test": "vp run -r test",
+		"test": "vp run -r build && vp test run",
 		"build": "vp run -r build"
 	},
 	"devDependencies": {

--- a/packages/oxlint/src/index.test.ts
+++ b/packages/oxlint/src/index.test.ts
@@ -28,7 +28,7 @@ function createOxlintFixture(source: string) {
 	return createFixture({
 		".oxlintrc.json": JSON.stringify({
 			categories: { correctness: "off" },
-			jsPlugins: [resolve("dist/index.mjs")],
+			jsPlugins: [resolve(import.meta.dirname, "../dist/index.mjs")],
 			rules: {
 				"ryoppippi/no-http-url": "error",
 				"ryoppippi/require-comment-on-useEffect": "error",
@@ -42,7 +42,7 @@ function runOxlint(cwd: string, ...arguments_: string[]) {
 	return spawnSync(
 		process.execPath,
 		[
-			resolve("node_modules/oxlint/bin/oxlint"),
+			resolve(import.meta.dirname, "../node_modules/oxlint/bin/oxlint"),
 			"--config",
 			".oxlintrc.json",
 			"input.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,7 @@ export default defineConfig({
 			typeCheck: true,
 		},
 	},
+	test: {
+		projects: ["packages/*"],
+	},
 });


### PR DESCRIPTION
## Summary

Run every package test as a single Vitest workspace from the root Vite+ config. The root test task builds package output first, then executes all package projects with one Vitest process; CI uses the same command.

Oxlint integration-test paths are now package-relative so they work from both package and workspace runners.

## Validation

- nix develop --command vp run test (4 files, 38 tests)
- nix develop --command vp run check
